### PR TITLE
fix: continue even if wiki repo is not existed

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,7 @@ runs:
       shell: bash
       run: pip install toml
     - uses: actions/checkout@v4
+      continue-on-error: true # Continue even if repo is not existed
       with:
         repository: ${{ github.repository }}.wiki
         sparse-checkout: |


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- GitHub Actionsの設定ファイル `action.yml` に `continue-on-error` オプションを追加しました。これにより、wiki リポジトリが存在しない場合でもワークフローが失敗せずに処理を続行できるようになります。


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>action.yml</strong><dd><code>GitHub Actions設定におけるエラー処理の改善</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

action.yml
<li><code>continue-on-error</code> オプションを追加し、wiki リポジトリが存在しない場合でも処理を継続できるように変更しました。<br>


</details>
    

  </td>
  <td><a href="https://github.com/idubnori/pr-agent-wiki-conf/pull/3/files#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

